### PR TITLE
Add error handling when procfile-parse returns empty string

### DIFF
--- a/buildpacks/test
+++ b/buildpacks/test
@@ -20,18 +20,7 @@ run-test() {
   cd - &> /dev/null
 	[[ "$CI" ]] || rmflag="--rm"
   [[ "$TRACE" ]] && debug_flag="-e TRACE=true"
-  run-invalid-proc-test
   docker run $rmflag $debug_flag --env=USER=herokuishuser -v "$app_path:/tmp/app" herokuish:dev /bin/herokuish test / "$app"
-}
-
-run-invalid-proc-test() {
-  echo "Running /start with invalid Proc Process"
-  local expected_err_msg="Proc entrypoint invalid-proc does not exist. Please check your Procfile"
-  local err_msg="$(docker run $rmflag $debug_flag --env=USER=herokuishuser -v "$app_path:/tmp/app" herokuish:dev /start invalid-proc)"
-  if [[ $err_msg != $expected_err_msg ]]; then
-    echo "/start did not throw error for invalid procfile"
-    exit 1
-  fi
 }
 
 main() {

--- a/buildpacks/test
+++ b/buildpacks/test
@@ -20,7 +20,18 @@ run-test() {
   cd - &> /dev/null
 	[[ "$CI" ]] || rmflag="--rm"
   [[ "$TRACE" ]] && debug_flag="-e TRACE=true"
+  run-invalid-proc-test
   docker run $rmflag $debug_flag --env=USER=herokuishuser -v "$app_path:/tmp/app" herokuish:dev /bin/herokuish test / "$app"
+}
+
+run-invalid-proc-test() {
+  echo "Running /start with invalid Proc Process"
+  local expected_err_msg="Proc entrypoint invalid-proc does not exist. Please check your Procfile"
+  local err_msg="$(docker run $rmflag $debug_flag --env=USER=herokuishuser -v "$app_path:/tmp/app" herokuish:dev /start invalid-proc)"
+  if [[ $err_msg != $expected_err_msg ]]; then
+    echo "/start did not throw error for invalid procfile"
+    exit 1
+  fi
 }
 
 main() {

--- a/include/procfile.bash
+++ b/include/procfile.bash
@@ -30,7 +30,13 @@ procfile-parse() {
 procfile-start() {
 	declare desc="Run process type command from Procfile through exec"
 	declare type="$1"
-	procfile-exec "$(procfile-parse "$type")"
+	local processcmd="$(procfile-parse "$type")"
+	if [[ -z "$processcmd" ]]; then
+		echo "Proc entrypoint ${type} does not exist. Please check your Procfile"
+		exit 1
+	else
+		procfile-exec $processcmd
+	fi
 }
 
 procfile-exec() {

--- a/tests/functional/tests.sh
+++ b/tests/functional/tests.sh
@@ -54,7 +54,7 @@ T_invalid_proc_process() {
  	
 	if [[ $err_msg != $expected_err_msg ]]; then
 		echo "procfile-start did not throw error for invalid procfile"
-    	exit 1
+		exit 1
   	fi
 }
 

--- a/tests/functional/tests.sh
+++ b/tests/functional/tests.sh
@@ -32,3 +32,12 @@ T_default-user() {
 	}
 	herokuish-test "test-user" "$(fn-source _test-user)"
 }
+
+T_invalid_proc_process() {
+  local expected_err_msg="Proc entrypoint invalid-proc does not exist. Please check your Procfile"
+  local err_msg=$(herokuish-test "inavlid-proc" "herokuish procfile start invalid-proc")
+  if [[ $err_msg != $expected_err_msg ]]; then
+    echo "procfile-start did not throw error for invalid procfile"
+    exit 1
+  fi
+}


### PR DESCRIPTION
## What?
- `/start` command runs `procfile-start` function with the supplied parameters.
- If the command is called with a process type that is either not a default one or is not defined in the app's Procfile, the `procfile-exec` throws the error `setuidgid: usage: setuidgid account child`.
  - This is because `procfile-parse` returns an empty string making the function fail

## Solution
- This PR adds simple error checking to the `procfile-start` function that errors out if the provided process type is not defined in the Procfile. If the process type is found, the function behaves as before

@stefanmb 
